### PR TITLE
Fix/preserve yaml structure

### DIFF
--- a/dbt_doc_py/dbt_doc_py.py
+++ b/dbt_doc_py/dbt_doc_py.py
@@ -355,8 +355,11 @@ def insert_column_description(env, node_result: SummarizedResult, col_map: Dict[
         with open(md_path, "w") as f:
             f.write(doc_content)
 
+    ## Removing the `columns` from dictionary only to be added after `description`
     model_node_.pop("description", None)
+    columns = model_node_.pop("columns", None)
     model_node_["description"] = f"{{{{ doc(\"{doc_name}\") }}}}"
+    model_node_["columns"] = columns
 
 def insert_description(env, node_map: Dict[str, SummarizedResult], model_node) -> None:    
     model_node_ = model_node

--- a/dbt_doc_py/dbt_doc_py.py
+++ b/dbt_doc_py/dbt_doc_py.py
@@ -5,6 +5,7 @@ import sys
 import json
 from enum import Enum
 import yaml
+from ruamel.yaml import YAML
 from dataclasses import dataclass
 import itertools
 import threading

--- a/dbt_doc_py/dbt_doc_py.py
+++ b/dbt_doc_py/dbt_doc_py.py
@@ -428,16 +428,16 @@ def insert_docs(env: Env, patch_path_may: Optional[str], nodes: List[SummarizedR
         if model_name in result_map:
             insert_description(env, result_map, model_obj)
 
-    yaml_output = yaml.dump(config, Dumper=yaml.SafeDumper)
-
     with stdout_lock:
         print(f"Adding description to {len(nodes)} models in {path}")
 
     if env.dry_run:
-        print(yaml_output)
+        ## Prints to console
+        YAML().dump(config, sys.stdout)
     else:
+        ## Writes to yaml file
         with open(path, "w") as f:
-            f.write(yaml_output)
+            YAML().dump(config, f)
 
 def read_project_config(base_path: str) -> str:
     path = os.path.join(base_path, "dbt_project.yml")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.1.17",
     packages=find_packages(),
     install_requires=[
-    "PyYAML", "dataclasses", "transformers", "argparse", "httpx", "inquirer",
+    "PyYAML", "dataclasses", "transformers", "argparse", "httpx", "inquirer", "ruamel.yaml",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Issue - Using PyYaml to write to yaml file does not guarantee the order of keys. #3 
Resolution-
- [x] Added new package `ruamel.yaml`, to be used for writing to yaml file. Added to setup.py file as well.
- [x] Updated code in function `insert_column_description`, to add description key immediately after model name.
- [x] Tested using replacing the `dbt_doc_py.py` file in site_packages with the updated code. Runs successfully.

Test output - 
[refer](https://github.com/munish7771/magicschool-dbt/commit/f9fd2445b2a10759d578635bb9b6ff9f421126a3)